### PR TITLE
Fix glob path separator issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "krankerl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krankerl"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Christoph Wurst <christoph@winzerhof-wurst.at>"]
 description = "A CLI helper to manage Nextcloud apps"
 

--- a/src/packaging/mod.rs
+++ b/src/packaging/mod.rs
@@ -19,7 +19,7 @@ use error;
 fn build_file_list(build_path: &Path, excludes: &exclude::ExcludedFiles) -> Vec<DirEntry> {
     WalkDir::new(build_path)
         .into_iter()
-        .filter_entry(|e| !excludes.is_excluded(e, build_path))
+        .filter_entry(|e| !excludes.is_excluded(e.path(), build_path))
         .map(|e| e.unwrap())
         .collect()
 }


### PR DESCRIPTION
The default glob configuration matches / with the * wildcard.
This caused some trouble with the mail app and thus I'm explicitly
excluding it to allow stricter exclude rules.