### PR TITLE
use color-eyre for error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b29030875fd8376e4a28ef497790d5b4a7843d8d1396bf08ce46f5eec562c5c"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "composer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +265,16 @@ dependencies = [
  "regex",
  "serde",
  "strsim",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -537,6 +574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d5eb2e114fec2b7fe0fadc22888ad2658789bb7acac4dbee9cf8389f971ec8"
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,10 +617,10 @@ name = "krankerl"
 version = "0.12.3"
 dependencies = [
  "base64",
+ "color-eyre",
  "composer",
  "dirs",
  "docopt",
- "failure",
  "flate2",
  "fs_extra",
  "git2",
@@ -850,6 +893,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parking_lot"
@@ -1275,6 +1324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,7 +1578,19 @@ checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1530,6 +1600,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ travis-ci = { repository = "ChristophWurst/krankerl", branch = "master" }
 [dependencies]
 base64 = "0.13"
 composer = "0.2"
+color-eyre = "0.5"
 docopt = "1.1"
 dirs = "3.0"
-failure = "0.1.8"
 flate2 = "1.0"
 hex = "0.4"
 ignore = "0.4.17"

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,13 +1,13 @@
 use std::fs;
 use std::path::PathBuf;
 
-use failure::Error;
+use color_eyre::{eyre::WrapErr, Result};
 
-pub fn clean(app_path: &PathBuf) -> Result<(), Error> {
+pub fn clean(app_path: &PathBuf) -> Result<()> {
     let artifacts_path = app_path.join("build").join("artifacts");
 
     if artifacts_path.exists() {
-        fs::remove_dir_all(artifacts_path)?;
+        fs::remove_dir_all(artifacts_path).wrap_err("Failed to remove artifact directory")?;
         println!("Build directory cleaned.");
     } else {
         println!("Nothing to clean.");

--- a/src/commands/disable.rs
+++ b/src/commands/disable.rs
@@ -1,12 +1,12 @@
-use failure::Error;
+use color_eyre::{eyre::WrapErr, Result};
 use nextcloud_appinfo::get_appinfo;
 
 use crate::occ::Occ;
 use std::path::Path;
 
-pub fn disable_app() -> Result<(), Error> {
-    let app_path = Path::new(".").canonicalize()?;
-    let info = get_appinfo(&app_path)?;
+pub fn disable_app() -> Result<()> {
+    let app_path = Path::new(".").canonicalize().wrap_err("Invalid app path")?;
+    let info = get_appinfo(&app_path).wrap_err("Failed to parse appinfo")?;
     let occ = Occ::new("../../occ");
-    occ.disable_app(info.id())
+    occ.disable_app(info.id()).wrap_err("Failed to enable app")
 }

--- a/src/commands/enable.rs
+++ b/src/commands/enable.rs
@@ -1,12 +1,12 @@
-use failure::Error;
 use nextcloud_appinfo::get_appinfo;
 
 use crate::occ::Occ;
+use color_eyre::{eyre::WrapErr, Result};
 use std::path::Path;
 
-pub fn enable_app() -> Result<(), Error> {
-    let app_path = Path::new(".").canonicalize()?;
-    let info = get_appinfo(&app_path)?;
+pub fn enable_app() -> Result<()> {
+    let app_path = Path::new(".").canonicalize().wrap_err("Invalid app path")?;
+    let info = get_appinfo(&app_path).wrap_err("Failed to parse appinfo")?;
     let occ = Occ::new("../../occ");
-    occ.enable_app(info.id())
+    occ.enable_app(info.id()).wrap_err("Failed to enable app")
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,8 +1,8 @@
-use failure::Error;
+use color_eyre::Result;
 use std::path::Path;
 
 use crate::config;
 
-pub fn init(app_path: &Path) -> Result<(), Error> {
+pub fn init(app_path: &Path) -> Result<()> {
     config::app::init_config(app_path)
 }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,11 +1,11 @@
-use failure::Error;
+use color_eyre::Result;
 
 use crate::config;
 
-pub fn log_in_to_appstore(token: &String) -> Result<(), Error> {
+pub fn log_in_to_appstore(token: &String) -> Result<()> {
     config::krankerl::set_appstore_token(token)
 }
 
-pub fn log_in_to_github(token: &String) -> Result<(), Error> {
+pub fn log_in_to_github(token: &String) -> Result<()> {
     config::krankerl::set_github_token(token)
 }

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
-use failure::Error;
+use color_eyre::Result;
 
 use crate::packaging::package_app as package;
 
-pub fn package_app(app_path: &PathBuf, shipped: bool) -> Result<(), Error> {
+pub fn package_app(app_path: &PathBuf, shipped: bool) -> Result<()> {
     package(app_path, shipped)
 }

--- a/src/commands/sign_package.rs
+++ b/src/commands/sign_package.rs
@@ -1,15 +1,15 @@
 use std::path::{Path, PathBuf};
 
+use color_eyre::{eyre::WrapErr, Report, Result};
 use dirs::home_dir;
-use failure::Error;
 use nextcloud_appinfo::get_appinfo;
 use nextcloud_appsignature;
 
-fn get_home_dir() -> Result<PathBuf, Error> {
-    home_dir().ok_or(format_err!("Could not resolve home dir",))
+fn get_home_dir() -> Result<PathBuf> {
+    home_dir().ok_or(Report::msg("Could not resolve home dir"))
 }
 
-fn get_private_key_path(app_id: &String) -> Result<PathBuf, Error> {
+fn get_private_key_path(app_id: &String) -> Result<PathBuf> {
     let mut key_path = get_home_dir()?;
     key_path.push(".nextcloud");
     key_path.push("certificates");
@@ -17,26 +17,31 @@ fn get_private_key_path(app_id: &String) -> Result<PathBuf, Error> {
     Ok(key_path)
 }
 
-fn get_package_path(app_id: &String) -> Result<PathBuf, Error> {
-    let mut path = PathBuf::from(".").canonicalize()?;
+fn get_package_path(app_id: &String) -> Result<PathBuf> {
+    let mut path = PathBuf::from(".")
+        .canonicalize()
+        .wrap_err("Invalid app path")?;
     path.push("build");
     path.push("artifacts");
     path.push(app_id.to_string() + ".tar.gz");
     Ok(path)
 }
 
-pub fn sign_package() -> Result<String, Error> {
-    let app_path = Path::new(".").canonicalize()?;
-    let appinfo = get_appinfo(&app_path)?;
+pub fn sign_package() -> Result<String> {
+    let app_path = Path::new(".").canonicalize().wrap_err("Invalid app path")?;
+    let appinfo = get_appinfo(&app_path).wrap_err("Failed to parse appinfo")?;
     let app_id = appinfo.id();
-    let key_path = get_private_key_path(app_id)?;
-    let package_path = get_package_path(app_id)?;
+    let key_path = get_private_key_path(app_id).wrap_err("Failed to get private key path")?;
+    let package_path = get_package_path(app_id).wrap_err("Failed to get package path")?;
 
     if !package_path.exists() {
-        bail!("No package found");
+        return Err(Report::msg(
+            "No built package found, build one using `krankerl package`",
+        ));
     }
 
-    let signature = nextcloud_appsignature::sign_package(&key_path, &package_path)?;
+    let signature = nextcloud_appsignature::sign_package(&key_path, &package_path)
+        .wrap_err("Failed to sign package")?;
 
     Ok(signature)
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::Path;
 
-use failure::Error;
+use color_eyre::{eyre::WrapErr, Report, Result};
 use nextcloud_appinfo;
 
 pub enum VersionChange {
@@ -13,14 +13,14 @@ pub enum VersionChange {
 }
 
 impl std::str::FromStr for VersionChange {
-    type Err = Error;
+    type Err = Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "major" => Ok(VersionChange::Major),
             "minor" => Ok(VersionChange::Minor),
             "patch" => Ok(VersionChange::Patch),
-            _ => Err(format_err!("Could not parse version bump type")),
+            _ => Err(Report::msg("Could not parse version bump type")),
         }
     }
 }
@@ -29,9 +29,9 @@ fn version_string(v: &nextcloud_appinfo::Version) -> String {
     format!("{}.{}.{}", v.major, v.minor, v.patch)
 }
 
-pub fn bump_version(bump: &str) -> Result<(), Error> {
+pub fn bump_version(bump: &str) -> Result<()> {
     let cwd = Path::new(".");
-    let app_info = nextcloud_appinfo::get_appinfo(&cwd)?;
+    let app_info = nextcloud_appinfo::get_appinfo(&cwd).wrap_err("Failed to parse info.xml")?;
     println!("current version is {}", app_info.version());
     let mut version = app_info.version().clone();
 
@@ -39,21 +39,30 @@ pub fn bump_version(bump: &str) -> Result<(), Error> {
         Ok(VersionChange::Major) => version.increment_major(),
         Ok(VersionChange::Minor) => version.increment_minor(),
         Ok(VersionChange::Patch) => version.increment_patch(),
-        _ => bail!("invalid argument supplied. Use major, minor or patch."),
+        _ => {
+            return Err(Report::msg(
+                "invalid argument supplied. Use major, minor or patch.",
+            ))
+        }
     };
 
     let mut info_file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open("./appinfo/info.xml")?;
+        .open("./appinfo/info.xml")
+        .wrap_err("Fauiled to open info.xml")?;
     let mut contents = String::new();
-    info_file.read_to_string(&mut contents)?;
+    info_file
+        .read_to_string(&mut contents)
+        .wrap_err("Failed to read info.xml")?;
     let new_contents = contents.replace(
         &version_string(app_info.version()),
         &version_string(&version),
     );
     info_file.seek(SeekFrom::Start(0))?;
-    info_file.write_all(new_contents.as_bytes())?;
+    info_file
+        .write_all(new_contents.as_bytes())
+        .wrap_err("Failed to write info.xml")?;
     println!("next version is {}", version);
     Ok(())
 }

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -3,11 +3,11 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 
-use failure::Error;
+use color_eyre::{eyre::WrapErr, Result};
 
 pub trait ConfigReader {
     fn has_config(&self) -> bool;
-    fn read(&self) -> Result<String, Error>;
+    fn read(&self) -> Result<String>;
 }
 
 pub struct ConfigFileReader {
@@ -28,10 +28,14 @@ impl ConfigReader for ConfigFileReader {
         File::open(&self.path).is_ok()
     }
 
-    fn read(&self) -> Result<String, Error> {
-        let mut file = File::open(&self.path)?;
+    fn read(&self) -> Result<String> {
+        let mut file = File::open(&self.path).wrap_err(format!(
+            "Failed to open config file '{}'",
+            self.path.to_string_lossy()
+        ))?;
         let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
+        file.read_to_string(&mut contents)
+            .wrap_err("Failed to read config file")?;
 
         Ok(contents)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,0 @@
-#[derive(Debug, Fail)]
-pub enum KrankerlError {
-    #[fail(display = "invalid toolchain name: {}", name)]
-    InvalidToolchainName { name: String },
-    #[fail(display = "exepected error: {}", cause)]
-    Other { cause: String },
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate failure;
 #[cfg(test)]
 extern crate fs_extra;
 #[macro_use]
@@ -7,17 +5,16 @@ extern crate serde_derive;
 
 pub mod commands;
 pub mod config;
-pub mod error;
 pub mod occ;
 pub mod packaging;
 
-use failure::Error;
+use color_eyre::Result;
 
 pub async fn publish_app(
     url: &String,
     is_nightly: bool,
     signature: &String,
     api_token: &String,
-) -> Result<(), Error> {
+) -> Result<()> {
     Ok(nextcloud_appstore::publish_app(url, is_nightly, signature, api_token).await?)
 }

--- a/src/occ.rs
+++ b/src/occ.rs
@@ -1,8 +1,7 @@
+use color_eyre::{eyre::WrapErr, Result};
 use std::convert;
 use std::ffi;
 use std::process::Command;
-
-use failure::Error;
 
 pub struct Occ<P> {
     path: P,
@@ -20,20 +19,22 @@ where
         Command::new(&self.path)
     }
 
-    fn invoke_command(&self, mut cmd: Command) -> Result<(), Error> {
+    fn invoke_command(&self, mut cmd: Command) -> Result<()> {
         cmd.status()?;
         Ok(())
     }
 
-    pub fn enable_app(&self, app_id: &String) -> Result<(), Error> {
+    pub fn enable_app(&self, app_id: &String) -> Result<()> {
         let mut cmd = self.start_command();
         cmd.arg("app:enable").arg(app_id);
         self.invoke_command(cmd)
+            .wrap_err(format!("Failed to run `occ app:enable` command"))
     }
 
-    pub fn disable_app(&self, app_id: &String) -> Result<(), Error> {
+    pub fn disable_app(&self, app_id: &String) -> Result<()> {
         let mut cmd = self.start_command();
         cmd.arg("app:disable").arg(app_id);
         self.invoke_command(cmd)
+            .wrap_err(format!("Failed to run `occ app:disable` command"))
     }
 }

--- a/src/packaging/archive.rs
+++ b/src/packaging/archive.rs
@@ -3,7 +3,8 @@ use std::io;
 use std::path::Path;
 use std::vec::Vec;
 
-use failure::Error;
+use color_eyre::eyre::WrapErr;
+use color_eyre::Result;
 use ignore::DirEntry;
 use pathdiff::diff_paths;
 use tar::Builder;
@@ -13,7 +14,7 @@ pub fn build_app_archive<W>(
     app_path: &Path,
     files: Vec<DirEntry>,
     dest: W,
-) -> Result<W, Error>
+) -> Result<W>
 where
     W: io::Write,
 {
@@ -25,7 +26,12 @@ where
             if let Some(normalized) = diff_paths(&entry_path, &app_path) {
                 let mut file_path = root.to_path_buf();
                 file_path.push(&normalized);
-                let mut file = File::open(&entry_path)?;
+                let mut file = File::open(&entry_path).wrap_err_with(|| {
+                    format!(
+                        "Failed to open {} for packaging",
+                        file_path.to_string_lossy()
+                    )
+                })?;
                 archive.append_file(file_path.as_path(), &mut file)?;
             }
         }

--- a/src/packaging/mod.rs
+++ b/src/packaging/mod.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
-use std::thread;
 
-use failure::Error;
+use color_eyre::Result;
 
 mod archive;
 mod artifacts;
@@ -9,36 +8,38 @@ mod commands;
 mod pipeline;
 
 use crate::packaging::pipeline::App;
+use color_eyre::eyre::WrapErr;
 
-fn build_archive(app_path: PathBuf) -> Result<(), Error> {
+fn build_archive(app_path: PathBuf) -> Result<()> {
     App::new(app_path)
         .clone()?
-        .install_dependencies()?
-        .build()?
-        .into_archive()?;
+        .install_dependencies()
+        .wrap_err("Failed to install dependencies")?
+        .build()
+        .wrap_err("Failed to build app")?
+        .into_archive()
+        .wrap_err("Failed to build app archive")?;
     Ok(())
 }
 
-fn build_shipped(app_path: PathBuf) -> Result<(), Error> {
+fn build_shipped(app_path: PathBuf) -> Result<()> {
     App::new(app_path)
         .clone()?
-        .install_dependencies()?
-        .build()?
-        .into_shipped()?;
+        .install_dependencies()
+        .wrap_err("Failed to install dependencies")?
+        .build()
+        .wrap_err("Failed to build app")?
+        .into_shipped()
+        .wrap_err("Failed to build app archive")?;
     Ok(())
 }
 
-pub fn package_app(app_path: &PathBuf, shipped: bool) -> Result<(), Error> {
+pub fn package_app(app_path: &PathBuf, shipped: bool) -> Result<()> {
     let app_path = app_path.clone();
 
-    let worker = thread::spawn(move || {
-        if shipped {
-            build_shipped(app_path)
-        } else {
-            build_archive(app_path)
-        }
-    });
-
-    worker.join().unwrap()?;
-    Ok(())
+    if shipped {
+        build_shipped(app_path)
+    } else {
+        build_archive(app_path)
+    }
 }

--- a/src/packaging/pipeline.rs
+++ b/src/packaging/pipeline.rs
@@ -1,7 +1,7 @@
 use std::fs::{copy, create_dir_all, File};
 use std::path::{Path, PathBuf};
 
-use failure::Error;
+use color_eyre::Result;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use ignore::{DirEntry, WalkBuilder};
@@ -30,7 +30,7 @@ impl App {
         }
     }
 
-    pub fn clone(self) -> Result<ClonedApp, Error> {
+    pub fn clone(self) -> Result<ClonedApp> {
         println!("Cloning app");
 
         let app_info = get_appinfo(&self.source_path)?;
@@ -57,7 +57,7 @@ impl ClonedApp {
         }
     }
 
-    pub fn install_dependencies(self) -> Result<AppWithDependencies, Error> {
+    pub fn install_dependencies(self) -> Result<AppWithDependencies> {
         // TODO: automatically install npm and composer dependencies
         // progress
         //    .as_ref()
@@ -83,7 +83,7 @@ impl AppWithDependencies {
         }
     }
 
-    pub fn build(self) -> Result<BuiltApp, Error> {
+    pub fn build(self) -> Result<BuiltApp> {
         println!("Building app");
 
         let opt_config = config::app::get_config(&self.app.source_path)?;
@@ -118,7 +118,7 @@ impl BuiltApp {
         }
     }
 
-    pub fn into_archive(self) -> Result<AppArchive, Error> {
+    pub fn into_archive(self) -> Result<AppArchive> {
         let mut compressed_archive_path = self.app.source_path.to_path_buf();
         compressed_archive_path.push("build");
         compressed_archive_path.push("artifacts");
@@ -147,7 +147,7 @@ impl BuiltApp {
         Ok(AppArchive::new(self))
     }
 
-    pub fn into_shipped(self) -> Result<ShippedApp, Error> {
+    pub fn into_shipped(self) -> Result<ShippedApp> {
         let mut ship_path = self.app.source_path.to_path_buf();
         ship_path.push("build");
         ship_path.push("artifacts");


### PR DESCRIPTION
Failure is deprecated and `color-eyre` allows for fancy error reporting:

Example when trying to bump the version while info.xml is malformed:

Before:
![Screenshot_20210220_164508](https://user-images.githubusercontent.com/1283854/108601288-c48e9f00-7393-11eb-8964-c77f8741acbb.png)

After:
![Screenshot_20210220_165044](https://user-images.githubusercontent.com/1283854/108601292-c8babc80-7393-11eb-845d-81bddbb0ed9c.png)
